### PR TITLE
Build currency structs at compile time

### DIFF
--- a/lib/currency.ex
+++ b/lib/currency.ex
@@ -312,10 +312,10 @@ defmodule Cldr.Currency do
       locale_name
       |> Cldr.Config.get_locale
       |> Map.get(:currencies)
+      |> Enum.map(fn {k, v} -> {k, struct(@struct, v)} end)
 
     def for_locale(%LanguageTag{cldr_locale_name: unquote(locale_name)}) do
       unquote(Macro.escape(currencies))
-      |> Enum.map(fn {k, v} -> {k, struct(__MODULE__, v)} end)
       |> Enum.into(%{})
     end
   end


### PR DESCRIPTION
Hey @kipcole9,

I experienced really slow requests on a Phoenix app. In our app, there is a loop that contains a `Cldr.Currency.for_code` call. This added a whopping 200-500ms to the request time!

In the Currency module, the structs are built on runtime for all currencies on each `for_code` and `for_locale` call. With this small change, structs are now built at compile time, and our Phoenix requests are back to comfortable 150-200 ms 😄